### PR TITLE
fix: Workflow Names

### DIFF
--- a/.github/workflows/eks-argocd-hotfix-release.yml
+++ b/.github/workflows/eks-argocd-hotfix-release.yml
@@ -99,7 +99,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: ./.github/workflows/workflows-ci-dockerized-app-build.yml
+    uses: ./.github/workflows/workflow-ci-dockerized-app-build.yml
     with:
       organization: ${{ inputs.organization }}
       repository: ${{ inputs.repository }}
@@ -113,13 +113,13 @@ jobs:
 
   release:
     needs: [ci]
-    uses: ./.github/workflows/workflows-controller-hotfix-release.yml
+    uses: ./.github/workflows/workflow-controller-hotfix-release.yml
     with:
       ref: ${{ github.sha }}
 
   promote:
     needs: [release]
-    uses: ./.github/workflows/workflows-ci-dockerized-app-promote.yml
+    uses: ./.github/workflows/workflow-ci-dockerized-app-promote.yml
     with:
       organization: ${{ inputs.organization }}
       repository: ${{ inputs.repository }}
@@ -132,7 +132,7 @@ jobs:
 
   cd:
     name: cd / production
-    uses: ./.github/workflows/workflows-cd-argocd.yml
+    uses: ./.github/workflows/workflow-cd-argocd.yml
     needs: [ promote ]
     with:
       image: ${{ needs.promote.outputs.image }}
@@ -149,7 +149,7 @@ jobs:
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}
 
   reintegrate:
-    uses: ./.github/workflows/workflows-controller-hotfix-reintegrate.yml
+    uses: ./.github/workflows/workflow-controller-hotfix-reintegrate.yml
     needs: [ cd ]
     with:
       ref: ${{ github.ref }}

--- a/.github/workflows/eks-argocd-main-branch.yml
+++ b/.github/workflows/eks-argocd-main-branch.yml
@@ -94,7 +94,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: ./.github/workflows/workflows-ci-dockerized-app-build.yml
+    uses: ./.github/workflows/workflow-ci-dockerized-app-build.yml
     with:
       organization: ${{ inputs.organization }}
       repository: ${{ inputs.repository }}
@@ -107,7 +107,7 @@ jobs:
       secret-outputs-passphrase: ${{ secrets.secret-outputs-passphrase }}
 
   cd:
-    uses: ./.github/workflows/workflows-cd-argocd.yml
+    uses: ./.github/workflows/workflow-cd-argocd.yml
     needs: [ ci ]
     with:
       image: ${{ needs.ci.outputs.image }}
@@ -124,7 +124,7 @@ jobs:
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}
 
   release:
-    uses:  ./.github/workflows/workflows-controller-draft-release.yml
+    uses:  ./.github/workflows/workflow-controller-draft-release.yml
     needs: [ cd ]
     secrets:
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}

--- a/.github/workflows/eks-argocd-release.yml
+++ b/.github/workflows/eks-argocd-release.yml
@@ -100,7 +100,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: ./.github/workflows/workflows-ci-dockerized-app-promote.yml
+    uses: ./.github/workflows/workflow-ci-dockerized-app-promote.yml
     with:
       organization: ${{ inputs.organization }}
       repository: ${{ inputs.repository }}
@@ -113,7 +113,7 @@ jobs:
 
   cd-staging:
     name: cd / staging
-    uses: ./.github/workflows/workflows-cd-argocd.yml
+    uses: ./.github/workflows/workflow-cd-argocd.yml
     needs: [ ci ]
     with:
       image: ${{ needs.ci.outputs.image }}
@@ -131,7 +131,7 @@ jobs:
 
   cd-production:
     name: cd / production
-    uses: ./.github/workflows/workflows-cd-argocd.yml
+    uses: ./.github/workflows/workflow-cd-argocd.yml
     needs: [ ci, cd-staging ]
     with:
       image: ${{ needs.ci.outputs.image }}


### PR DESCRIPTION
# What

Renamed all `workflows-*` to `workflow-*` in each reusable workflow call

# Why

Typo in filenames

# Ref
https://github.com/cloudposse-examples/app-on-eks-with-argocd/actions/runs/7732874765