### PR TITLE
fix(DEV-1567): release drafter

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+### TP Card:
+* [TP-ID_Number](TP_URL)
+
+### Why?:
+*
+
+### What's Done:
+*
+
+### Does this PR include specs for any new or modified code?
+
+1. [ ] :white_check_mark:
+2. [ ] :question:  Not sure?  Please reach out to another developer for assistance
+3. [ ] :x:  **REQUIRED:  please provide an explanation describing why this PR is missing specs**
+  - Explanation:
+
+### Are there any security considerations for this PR?
+
+1. [ ] :white_check_mark:
+2. [ ] :x:
+- Please elaborate as needed:
+
+### Does this PR ensure?
+
+- [ ] No business logic in view (.erb files)
+- [ ] Object level assumption is verified (e.g. handle null object appropriately)
+* Note - Dev to confirm the above during PR creation.
+
+### Was the code you're committing subject to a design review?
+
+- [ ] Yes
+- [ ] No, but I'm **certain** the change is isolated and will not negatively impact other features or performance generally
+- [ ] No, and I'm not sure what impact my change will have on other features and performance generally
+
+
+### Browser Tested:
+
+- [ ] Chrome
+- [ ] Others
+- [ ] N/A
+
+### Screenshot or GIF:
+
+**Mandatory** — You need to attach a screenshot/screen-cast if you made any changes to the UI

--- a/.github/workflows/eks-argocd-main-branch.yml
+++ b/.github/workflows/eks-argocd-main-branch.yml
@@ -126,5 +126,3 @@ jobs:
   release:
     uses:  ./.github/workflows/workflow-controller-draft-release.yml
     needs: [ cd ]
-    secrets:
-      github-private-actions-pat: ${{ secrets.github-private-actions-pat }}

--- a/.github/workflows/workflow-controller-draft-release.yml
+++ b/.github/workflows/workflow-controller-draft-release.yml
@@ -16,8 +16,6 @@ name: |-
         uses:  ./.github/workflows/workflow-controller-draft-release.yml@main
         with:
           ref: $\{\{ github.sha \}\}
-        secrets:
-          github-private-actions-pat: $\{\{ secrets.github-private-actions-pat \}\}
 
   ```
 
@@ -30,10 +28,6 @@ on:
         default: ${{ github.sha }}
         type: string
 
-    secrets:
-      github-private-actions-pat:
-        description: "Github PAT allow to create release"
-        required: true
 jobs:
   draft:
     runs-on: ubuntu-latest
@@ -46,5 +40,3 @@ jobs:
           prerelease: false
           config-name: configs/draft-release.yml
           commitish: ${{ inputs.ref }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.github-private-actions-pat }}


### PR DESCRIPTION
# what

dont pass PAT to release drafter

# why

default `GITHUB_TOKEN` has appropriate access, PAT doesnt

# ref

https://stackoverflow.com/questions/67389957/what-permissions-does-github-token-require-for-releases-from-a-github-action