### PR TITLE
feat: Use ECR for remote buildx caching

### DIFF
--- a/.github/workflows/workflow-ci-dockerized-app-build.yml
+++ b/.github/workflows/workflow-ci-dockerized-app-build.yml
@@ -85,6 +85,8 @@ jobs:
           organization: ${{ inputs.organization }}
           repository: ${{ inputs.repository }}
           registry: ${{ secrets.registry }}
+          cache-from: "type=registry,ref=${{ secrets.registry }}/${{ inputs.organization }}/${{ inputs.repository }}:cache"
+          cache-to: "mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${{ secrets.registry }}/${{ inputs.organization }}/${{ inputs.repository }}:cache"
 
       - uses: cloudposse/github-action-secret-outputs@0.1.1
         id: image


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

* Use ECR for remote buildx caching

## why

<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

* https://github.com/cloudposse-examples/app-on-eks-with-argocd/actions/runs/8348130590/job/22849341517?pr=32

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
- Use `closes JIRA-123`, if this PR closes a Jira Issue `JIRA-123` where `JIRA` is the project abbreviation. 
-->

* https://github.com/cloudposse/github-action-docker-build-push/pull/61
* https://aws.amazon.com/blogs/containers/announcing-remote-cache-support-in-amazon-ecr-for-buildkit-clients/